### PR TITLE
[noticket] Remove .composer-folder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,9 @@ USER root
 RUN apt-get update -q \
     && apt-get upgrade -y -q \
     && apt-get install -y patch \
-    && cd /usr/local/bin/ \
     && rm -f /usr/local/bin/composer \
+    && rm -rf ~/.composer \
+    && cd /usr/local/bin/ \
     && chmod 755 composer1 composer2 \
     && ln -s composer2 composer \
     && apt-get autoremove -yq --purge \


### PR DESCRIPTION
* Remove installed composer packages according to error in version 3.2.9 of composer with hirak/prestissimo